### PR TITLE
Updated dependencies, UB2, 15.6 target, still at Swift v5 though

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,23 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-target "Shelley" do
-  platform :osx, "10.14"
-  inhibit_all_warnings!
-  pod 'Sparkle'
-  pod 'Criollo', '~> 0.5'
+platform :osx, '15.0'
+use_frameworks!
+
+target 'Shelley' do
+  pod 'Sparkle', '~> 2.0'
+  pod 'Criollo', '~> 1.0'
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    if target.name == 'CocoaAsyncSocket'
+      umbrella_path = "#{installer.sandbox.target_support_files_dir(target.name)}/#{target.name}-umbrella.h"
+      if File.exist?(umbrella_path)
+        contents = File.read(umbrella_path)
+        contents.gsub!(/#import "GCDAsyncSocket.h"/, '#import <CocoaAsyncSocket/GCDAsyncSocket.h>')
+        contents.gsub!(/#import "GCDAsyncUdpSocket.h"/, '#import <CocoaAsyncSocket/GCDAsyncUdpSocket.h>')
+        File.write(umbrella_path, contents)
+      end
+    end
+  end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - CocoaAsyncSocket (7.6.4)
-  - Criollo (0.5.5):
-    - CocoaAsyncSocket (~> 7.6)
-  - Sparkle (1.23.0)
+  - CocoaAsyncSocket (7.6.5)
+  - Criollo (1.1.0):
+    - CocoaAsyncSocket (~> 7.6.5)
+  - Sparkle (2.8.1)
 
 DEPENDENCIES:
-  - Criollo (~> 0.5)
-  - Sparkle
+  - Criollo (~> 1.0)
+  - Sparkle (~> 2.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -15,10 +15,10 @@ SPEC REPOS:
     - Sparkle
 
 SPEC CHECKSUMS:
-  CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
-  Criollo: 617173837c296ca4248b0b058f36ce9b91e5c25b
-  Sparkle: 55b1a87ba69d56913375a281546b7c82dec95bb0
+  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
+  Criollo: 7e97de7e9231f080dbe58585f410a1779eca5828
+  Sparkle: a346a4341537c625955751ed3ae4b340b68551fa
 
-PODFILE CHECKSUM: bc9d5270465959491452d93b0cf4a7fcfb0fa41c
+PODFILE CHECKSUM: 7f051017b517c4f6a4bcb3d6134503772a09cc96
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.11.3

--- a/Shelley.xcodeproj/project.pbxproj
+++ b/Shelley.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1399ABCB446F12568456E990 /* Pods_Shelley.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8CC5E6F7421531DA5EAE70E /* Pods_Shelley.framework */; };
 		C6512D3C24F727B800EB2AB7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6512D3B24F727B800EB2AB7 /* AppDelegate.swift */; };
 		C6512D3E24F727BA00EB2AB7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C6512D3D24F727BA00EB2AB7 /* Assets.xcassets */; };
 		C6512D4124F727BA00EB2AB7 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = C6512D3F24F727BA00EB2AB7 /* MainMenu.xib */; };
@@ -22,7 +23,6 @@
 		C6512D6424F736B500EB2AB7 /* Server.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6512D6324F736B500EB2AB7 /* Server.swift */; };
 		C65236DF24F7499C008A4577 /* TaskRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65236DE24F7499C008A4577 /* TaskRunner.swift */; };
 		C65236E124F74F6B008A4577 /* Defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = C65236E024F74F6B008A4577 /* Defaults.plist */; };
-		F9B850C273B565E14F2B0B1B /* libPods-Shelley.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBA1B28D70E05972D29E051 /* libPods-Shelley.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -39,11 +39,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1CBA1B28D70E05972D29E051 /* libPods-Shelley.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Shelley.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D6F69593073EA64FF080D8B /* Pods-RequestBar.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RequestBar.debug.xcconfig"; path = "Target Support Files/Pods-RequestBar/Pods-RequestBar.debug.xcconfig"; sourceTree = "<group>"; };
 		9B4470F070F997A74B879D74 /* Pods-RequestBar.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RequestBar.release.xcconfig"; path = "Target Support Files/Pods-RequestBar/Pods-RequestBar.release.xcconfig"; sourceTree = "<group>"; };
 		9FC372CFF153D8D3E7222F86 /* Pods-Shelley.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shelley.release.xcconfig"; path = "Target Support Files/Pods-Shelley/Pods-Shelley.release.xcconfig"; sourceTree = "<group>"; };
 		B3EF497A753691E0BB27D6C8 /* Pods-Shelley.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shelley.debug.xcconfig"; path = "Target Support Files/Pods-Shelley/Pods-Shelley.debug.xcconfig"; sourceTree = "<group>"; };
+		B8CC5E6F7421531DA5EAE70E /* Pods_Shelley.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Shelley.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6512D3824F727B800EB2AB7 /* Shelley.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shelley.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6512D3B24F727B800EB2AB7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C6512D3D24F727BA00EB2AB7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -69,7 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F9B850C273B565E14F2B0B1B /* libPods-Shelley.a in Frameworks */,
+				1399ABCB446F12568456E990 /* Pods_Shelley.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,7 +90,7 @@
 		6610344A598B30E0E8BB6055 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				1CBA1B28D70E05972D29E051 /* libPods-Shelley.a */,
+				B8CC5E6F7421531DA5EAE70E /* Pods_Shelley.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -166,8 +166,9 @@
 		C6512D3024F727B800EB2AB7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1160;
-				LastUpgradeCheck = 1160;
+				LastUpgradeCheck = 2620;
 				ORGANIZATIONNAME = "Tyler Hall";
 				TargetAttributes = {
 					C6512D3724F727B800EB2AB7 = {
@@ -219,9 +220,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Shelley/Pods-Shelley-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Shelley/Pods-Shelley-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -309,16 +314,22 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -333,11 +344,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -369,16 +381,22 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -387,10 +405,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
@@ -404,15 +423,19 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = 3A6K89K388;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Shelley/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Shelley;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.tyler.Shelley;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Shelley/Shelley-Bridging-Header.h";
@@ -430,15 +453,19 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = 3A6K89K388;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Shelley/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Shelley;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.tyler.Shelley;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Shelley/Shelley-Bridging-Header.h";

--- a/Shelley.xcodeproj/project.pbxproj
+++ b/Shelley.xcodeproj/project.pbxproj
@@ -421,10 +421,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Shelley/Info.plist;
@@ -440,7 +442,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Shelley/Shelley-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -451,10 +453,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Shelley/Info.plist;
@@ -469,7 +473,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.tyler.Shelley;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Shelley/Shelley-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/Shelley.xcodeproj/xcshareddata/xcschemes/Shelley.xcscheme
+++ b/Shelley.xcodeproj/xcshareddata/xcschemes/Shelley.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "All">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C6512D3724F727B800EB2AB7"
+               BuildableName = "Shelley.app"
+               BlueprintName = "Shelley"
+               ReferencedContainer = "container:Shelley.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C6512D3724F727B800EB2AB7"
+            BuildableName = "Shelley.app"
+            BlueprintName = "Shelley"
+            ReferencedContainer = "container:Shelley.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C6512D3724F727B800EB2AB7"
+            BuildableName = "Shelley.app"
+            BlueprintName = "Shelley"
+            ReferencedContainer = "container:Shelley.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Shelley/AboutWindowController.xib
+++ b/Shelley/AboutWindowController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +16,7 @@
         <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="QvC-M9-y7g" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" fullSizeContentView="YES"/>
             <rect key="contentRect" x="196" y="240" width="437" height="163"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="437" height="163"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -26,7 +26,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="Icon" id="e5I-gX-lie"/>
                     </imageView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Kw-cn-FWi">
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Kw-cn-FWi">
                         <rect key="frame" x="155" y="55" width="264" height="23"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Version 0.0.0" id="zak-R5-vCn">
@@ -35,7 +35,7 @@
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7st-ex-v8h">
+                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7st-ex-v8h">
                         <rect key="frame" x="155" y="20" width="232" height="28"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Copyright © 2020 Click On Tyler." id="BUj-6w-DKO">
@@ -44,7 +44,7 @@
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mmR-SW-mRC">
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mmR-SW-mRC">
                         <rect key="frame" x="151" y="74" width="264" height="60"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shelley" id="wLu-aP-771">

--- a/Shelley/AppDelegate.swift
+++ b/Shelley/AppDelegate.swift
@@ -8,9 +8,10 @@
 
 import Cocoa
 
-var updaterController: SPUStandardUpdaterController?
+@MainActor var updaterController: SPUStandardUpdaterController?
 
-@NSApplicationMain
+@main
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBOutlet weak var statusBarMenu: NSMenu!

--- a/Shelley/AppDelegate.swift
+++ b/Shelley/AppDelegate.swift
@@ -8,6 +8,8 @@
 
 import Cocoa
 
+var updaterController: SPUStandardUpdaterController?
+
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
@@ -30,10 +32,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if launchCount() == 1 {
             showWelcomePopover(nil)
         }
-
+        
         Server.shared.start()
-
-        SUUpdater.shared()?.checkForUpdatesInBackground()
+                
+        updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
     }
 
     func registerDefaults() {
@@ -76,8 +78,8 @@ extension AppDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    @IBAction func checkForUpdates(_ sender: AnyObject?) {
-        SUUpdater.shared()?.checkForUpdates(nil)
+    @IBAction func checkForUpdates(_ sender: Any?) {
+        updaterController?.checkForUpdates(sender)
     }
 
     @IBAction func quit(_ sender: AnyObject?) {

--- a/Shelley/Base.lproj/MainMenu.xib
+++ b/Shelley/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -11,7 +11,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="RequestBar" customModuleProvider="target">
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Shelley" customModuleProvider="target">
             <connections>
                 <outlet property="statusBarMenu" destination="Kmc-Ur-Bdv" id="aXd-eR-YX5"/>
             </connections>
@@ -101,7 +101,8 @@
                                     <action selector="saveDocument:" target="-1" id="teZ-XB-qJY"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                            <menuItem title="Save As…" keyEquivalent="s" id="Bw7-FT-i3A">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
                                     <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
                                 </connections>

--- a/Shelley/Constants.swift
+++ b/Shelley/Constants.swift
@@ -30,7 +30,7 @@ class Constants {
         if FileManager.default.fileExists(atPath: scriptFolderURL.path) {
             let keyURL = scriptFolderURL.appendingPathComponent("key").appendingPathExtension("txt")
             if FileManager.default.fileExists(atPath: keyURL.path) {
-                return try? String(contentsOf: keyURL)
+                return try? String(contentsOf: keyURL, encoding: .utf8)
             } else {
                 let key = UUID().uuidString
                 do {

--- a/Shelley/MenuBarStatusItem.swift
+++ b/Shelley/MenuBarStatusItem.swift
@@ -8,6 +8,7 @@
 
 import AppKit
 
+@MainActor
 class MenuBarStatusItem {
 
     var statusItem: NSStatusItem?

--- a/Shelley/PrefsWindowController.xib
+++ b/Shelley/PrefsWindowController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +16,7 @@
         <window title="Shelley" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="Preferences" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <rect key="contentRect" x="196" y="240" width="362" height="118"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="362" height="118"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -25,7 +25,7 @@
                         <rect key="frame" x="12" y="54" width="338" height="5"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </box>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G6H-Tv-GLM">
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G6H-Tv-GLM">
                         <rect key="frame" x="18" y="82" width="86" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Script Folder:" id="bej-rT-8i1">

--- a/Shelley/Server.swift
+++ b/Shelley/Server.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class Server {
 
-    static let shared = Server()
+    @MainActor static let shared = Server()
 
     let HTTPServer = CRHTTPServer()
     

--- a/Shelley/WelcomePopover.xib
+++ b/Shelley/WelcomePopover.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,11 +13,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="192" height="206"/>
+            <rect key="frame" x="0.0" y="0.0" width="192" height="205"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="16" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sn1-iC-cXg">
-                    <rect key="frame" x="24" y="63" width="144" height="132"/>
+                    <rect key="frame" x="24" y="62" width="144" height="132"/>
                     <subviews>
                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KCL-JQ-d9R">
                             <rect key="frame" x="24" y="36" width="96" height="96"/>
@@ -27,7 +27,7 @@
                             </constraints>
                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="Icon" id="MuN-3o-V1V"/>
                         </imageView>
-                        <textField horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="SSq-Zs-Wi4">
+                        <textField focusRingType="none" horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="SSq-Zs-Wi4">
                             <rect key="frame" x="38" y="0.0" width="68" height="20"/>
                             <textFieldCell key="cell" selectable="YES" alignment="center" title="Shelley" id="ZsS-OC-zP3">
                                 <font key="font" metaFont="systemBold" size="17"/>
@@ -49,7 +49,7 @@
                     </customSpacing>
                 </stackView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5da-EL-AOD">
-                    <rect key="frame" x="4" y="15" width="185" height="32"/>
+                    <rect key="frame" x="7" y="15" width="179" height="32"/>
                     <buttonCell key="cell" type="push" title="Choose Scripts Folder..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="zVe-kn-l1M">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>


### PR DESCRIPTION
December 2025 updates: new dependencies (pods), macOS 15.6 target, universal binary; still set to Swift v5

Caveats: when cleaning up, I noticed that I hadn't set the Swift version to 6, i.e. it's still on v5. Maybe it's better to move it to v6 too. (Don't know if other warnings or even errors will appear. Not tested.)

Explanations:

(1) Podfile: needs `use_frameworks!` – otherwise Criollo wouldn't import CocoaAsyncSocket

(2) Podfile: newer versions with target macOS 15.0; NOTE: I noticed that, whenever I update/reload the pods for building, Xcode will downgrade the target of the individual pods/frameworks from Sequoia to older macOS versions, including 10.8. (Maybe there's a setting somewhere to override that. I'm anything but proficient, when it comes to Xcode.)

(3) Podfile: post-install script, because in one file CocoaAsyncSocket uses double-quotes for import, not angled brackets, as expected by Xcode; using the newer Xcode & setting a recent macOS target version resulted in the build failing with errors, if the double-quotes were left in

(4) general: code-signing identity removed; your dev certificate/team needs to be re-added

(5) general: at some point I also upped the version number to v1.0.2 somewhere in the project, but it didn't propagate to the Info.plist, so you might want to check that

(6) AppDelegate.swift: only three lines to make it conform to Sparkle v2+

(7) Constants.swift: replaced `return try? String(contentsOf: keyURL)` with `return try? String(contentsOf: keyURL, encoding: .utf8)` (deprecated syntax)

(8) other stuff is just what Xcode put in there during the work
